### PR TITLE
Bump JDK11 version to 11.0.20.1_1

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION=11.0.20.1_1
 FROM almalinux:8.8 as jre-build
-ARG JAVA_VERSION
+ARG JAVA_VERSION=11.0.20.1_1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="11.0.20.1_1"
+ARG JAVA_VERSION=11.0.20.1_1
 ARG BOOKWORM_TAG=20230919
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="11.0.20.1_1"
+ARG JAVA_VERSION=11.0.20.1_1
 ARG BOOKWORM_TAG=20230919
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION=11.0.20.1_1
 FROM registry.access.redhat.com/ubi8/ubi:8.8-1032.1692772289 as jre-build
-ARG JAVA_VERSION
+ARG JAVA_VERSION=11.0.20.1_1
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 


### PR DESCRIPTION



<Actions>
    <action id="350479c434ae023cf9e587b8f5d4439f97ff4185513c3a1a66b25454ad7f2a47">
        <h3>Bump JDK11 version</h3>
        <details id="e1563bb8da7de482c394f660c4781be8ba97708b860ab71efcbce877bd52bad5">
            <summary>Bump JDK11 version for Linux images in the Alma Linux 8 Dockerfile</summary>
            <p>changed lines [3] of file &#34;/tmp/updatecli/github/gounthar/docker/11/almalinux/almalinux8/hotspot/Dockerfile&#34;</p>
            <details>
                <summary>11.0.20.1_1</summary>
                <pre>&#xA;Release published on the 2023-08-29 14:10:55 +0000 UTC at the url https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20.1%2B1&#xA;&#xA;Official Release of jdk-11.0.20.1+1</pre>
            </details>
        </details>
        <details id="f146886468708c9b2d49a7be9652726c6f40ff264c9894b214bc13a449a63482">
            <summary>Bump JDK11 version for Linux images in the Debian Dockerfile</summary>
            <p>changed lines [1] of file &#34;/tmp/updatecli/github/gounthar/docker/11/debian/bookworm/hotspot/Dockerfile&#34;</p>
            <details>
                <summary>11.0.20.1_1</summary>
                <pre>&#xA;Release published on the 2023-08-29 14:10:55 +0000 UTC at the url https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20.1%2B1&#xA;&#xA;Official Release of jdk-11.0.20.1+1</pre>
            </details>
        </details>
        <details id="c96361bfd92eb40f57896659fd4fe01b43d3a917b1eaadd9b93b7cddecb579b9">
            <summary>Bump JDK11 version for Linux images in the Debian Slim Dockerfile</summary>
            <p>changed lines [1] of file &#34;/tmp/updatecli/github/gounthar/docker/11/debian/bookworm-slim/hotspot/Dockerfile&#34;</p>
            <details>
                <summary>11.0.20.1_1</summary>
                <pre>&#xA;Release published on the 2023-08-29 14:10:55 +0000 UTC at the url https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20.1%2B1&#xA;&#xA;Official Release of jdk-11.0.20.1+1</pre>
            </details>
        </details>
        <details id="abfc70ccd48ba84b4c0585a48a84b275d5febd1b1fcd18ab2575135259009dd0">
            <summary>Bump JDK11 version for Linux images in the Rhel Dockerfile</summary>
            <p>changed lines [3] of file &#34;/tmp/updatecli/github/gounthar/docker/11/rhel/ubi8/hotspot/Dockerfile&#34;</p>
            <details>
                <summary>11.0.20.1_1</summary>
                <pre>&#xA;Release published on the 2023-08-29 14:10:55 +0000 UTC at the url https://github.com/adoptium/temurin11-binaries/releases/tag/jdk-11.0.20.1%2B1&#xA;&#xA;Official Release of jdk-11.0.20.1+1</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

